### PR TITLE
Possible fix for aiff input (Linux, i586), clang warnings

### DIFF
--- a/dist10/lsf/decoder/makefile
+++ b/dist10/lsf/decoder/makefile
@@ -14,7 +14,7 @@
 ############################################################################
 
 # MODE= -O -DUNIX
-MODE= -g -DUNIX -Wall -Wextra -pedantic
+MODE= -g -DUNIX -Wall -Wextra -pedantic -Wno-implicit-function-declaration -Wno-implicit-int
 #MODE= -DMSC60 -AH -Zi -Gt
 OBJ_SUFFIX=.o
 EXE_SUFFIX=

--- a/dist10/lsf/encoder/makefile
+++ b/dist10/lsf/encoder/makefile
@@ -13,7 +13,7 @@
 ############################################################################
 
 # MODE= -O -DUNIX
-MODE= -g -DUNIX
+MODE= -g -DUNIX -Wno-implicit-function-declaration -Wno-implicit-int
 #MODE= -DMSC60 -AH -Zi -Gt
 OBJ_SUFFIX=.o
 EXE_SUFFIX=

--- a/dist10/mc/decoder/common.h
+++ b/dist10/mc/decoder/common.h
@@ -200,6 +200,7 @@
 #ifdef  UNIX
 #include        <unistd.h>	 /* removed 92-08-05 shn */
 #include	<stdlib.h>       /* put in 92-08-05 shn */
+#include <stdint.h>
 #endif  /* UNIX */
 
 #ifdef  MACINTOSH
@@ -445,40 +446,40 @@ typedef struct  identifier_struct{
 
 typedef struct  ChunkHeader_struct {
 				ID      ckID;
-				long    ckSize;
+				int32_t    ckSize;
 } ChunkHeader;
 
 typedef struct  Chunk_struct {
 				ID      ckID;
-				long    ckSize;
+				int32_t    ckSize;
 				ID      formType;
 } Chunk;
 
 typedef struct  CommonChunk_struct {
 				ID              ckID;
-				long            ckSize;
-				short           numChannels;
-				unsigned long   numSampleFrames;
-				short           sampleSize;
+				int32_t            ckSize;
+				int16_t           numChannels;
+				uint32_t   numSampleFrames;
+				int16_t           sampleSize;
 				char            sampleRate[10];
 } CommonChunk;
 
 typedef struct  SoundDataChunk_struct {
 				ID              ckID;
-				long            ckSize;
-				unsigned long   offset;
-				unsigned long   blockSize;
+				int32_t            ckSize;
+				uint32_t   offset;
+				uint32_t   blockSize;
 } SoundDataChunk;
 
 typedef struct  blockAlign_struct {
-				unsigned long   offset;
-				unsigned long   blockSize;
+				uint32_t   offset;
+				uint32_t   blockSize;
 } blockAlign;
 
 typedef struct  IFF_AIFF_struct {
-				short           numChannels;
-                unsigned long   numSampleFrames;
-                short           sampleSize;
+				int16_t           numChannels;
+                uint32_t   numSampleFrames;
+                int16_t           sampleSize;
 		double          sampleRate;
                 ID/*char**/     sampleType;/*must be allocated 21.6.93 SR*/
                 blockAlign      blkAlgn;

--- a/dist10/mc/decoder/decode.c
+++ b/dist10/mc/decoder/decode.c
@@ -2540,6 +2540,11 @@ int SubBandSynthesis_ml (double *bandPtr,
     return (clip);
 }
 
+//! Byte swap short
+static int16_t swap_int16( int16_t val ) 
+{
+    return (val << 8) | ((val >> 8) & 0xFF);
+}
 
 void out_fifo (long pcm_sample[7][3][SBLIMIT],
 	       int num,
@@ -2565,7 +2570,7 @@ static long k = 0;
 			fwrite (outsamp, 2, 1600, outFile);
 			k = 0;
 		    }
-		    outsamp[k++] = pcm_sample[l][i][j];
+		    outsamp[k++] = swap_int16(pcm_sample[l][i][j]);
 		}
 	    }
     else if (k > 0)

--- a/dist10/mc/decoder/musicout.c
+++ b/dist10/mc/decoder/musicout.c
@@ -189,7 +189,7 @@ double		   S_freq;
 
 /* Implementations */
 
-main (int argc, char **argv)  /* R.S. 7 channels for ML */
+int main (int argc, char **argv)  /* R.S. 7 channels for ML */
 {
 typedef long PCM[7][3][SBLIMIT];		
 	PCM  *pcm_sample;
@@ -320,7 +320,7 @@ typedef double VE[7][HAN_SIZE];
 	   do
 	   {
 		  printf ("Enter encoded file name <required>: ");
-		  gets (encoded_file_name);
+		  fgets (encoded_file_name,81,stdin);
 		  f = strlen(encoded_file_name)-4;	  /*cut off extension.8/11/92.sr*/
 		  if (encoded_file_name[0] == NULL_CHAR)
 			 printf ("Encoded file name is required. \n");
@@ -330,7 +330,7 @@ typedef double VE[7][HAN_SIZE];
 	   strcpy(encoded_file_name1, encoded_file_name);  /*8/11/92.sr*/
 	   strcpy(&encoded_file_name1[f], DFLT_OPEXT_DEC);	  /*.dec-extension.8/11/92.sr*/
 	   printf ("Enter MPEG decoded file name <%s>: ", encoded_file_name1);
-	   gets (decoded_file_name);
+	   fgets (decoded_file_name,81,stdin);
 	   if (decoded_file_name[0] == NULL_CHAR)
 		strcpy(decoded_file_name, encoded_file_name1);
 
@@ -342,7 +342,7 @@ typedef double VE[7][HAN_SIZE];
 	   strcpy(encoded_file_name1, encoded_file_name);
 	   strcpy(&encoded_file_name1[f], DFLT_IPEXT_EXT);	  /* .ext */
 	   printf (">>> Enter MPEG 2 decoded extension filename <%s>: ", encoded_file_name1);
-	   gets(ext_bitstream_name);
+	   fgets(ext_bitstream_name,81,stdin);
 	   if( ext_bitstream_name[0] == NULL_CHAR )
 		strcpy(ext_bitstream_name, encoded_file_name1);
 	   printf("Extension bitstream <%s> will be decoded \n",ext_bitstream_name);
@@ -351,7 +351,7 @@ typedef double VE[7][HAN_SIZE];
 	   { 	
 		printf("No extension bitstream <%s> present \n",ext_bitstream_name);
 		printf("Do you want to decode an MPEG 2 bitstream ? (<y>/n) : ");
-		gets(t);
+		fgets(t,81,stdin);
 	   	if (*t == 'N' || *t == 'n') 
 		{
 			mpeg = 1;
@@ -364,7 +364,7 @@ typedef double VE[7][HAN_SIZE];
 		}
 	   } 
 	   printf("Do you wish to write an AIFF compatible sound file ? (<y>/n) : ");
-	   gets(t);
+	   fgets(t,81,stdin);
 	   if (*t == 'N' || *t == 'n') need_aiff = FALSE;
 	   else                        need_aiff = TRUE;
 	   if (need_aiff)
@@ -372,13 +372,13 @@ typedef double VE[7][HAN_SIZE];
 	   else printf(">>> A non-headered PCM sound file will be written\n");
 	   
 	   printf("Do you want to print out all decoding information ? (y/<n>) :");
-	   gets(t);
+	   fgets(t,81,stdin);
 	   if( *t == 'y' || *t == 'Y' ) print_out = 1;
 	   else		      		print_out = 0;
 
 	   printf(
 		  "Do you wish to exit (last chance before decoding) ? (y/<n>) : ");
-	   gets(t);
+	   fgets(t,81,stdin);
 	   if (*t == 'y' || *t == 'Y') exit(0);
 	}
 

--- a/dist10/mc/encoder/encode.c
+++ b/dist10/mc/encoder/encode.c
@@ -1040,7 +1040,7 @@ void window_subband (double **buffer, double *z, int k)
     typedef double XX[14][HAN_SIZE];	/* 08/03/1995 JMZ Multilingual */
     static XX *x;
     int i, j;
-    static off[14]= {0,0,0,0,0,0,0,0,0,0,0,0,0,0};/* 08/03/1995 JMZ Multilingual */
+    static int off[14]= {0,0,0,0,0,0,0,0,0,0,0,0,0,0};/* 08/03/1995 JMZ Multilingual */
     static char init = 0;
     static double *c;
  

--- a/dist10/mc/encoder/encode.c
+++ b/dist10/mc/encoder/encode.c
@@ -171,6 +171,7 @@
 
 #include "common.h"
 #include "encoder.h"
+#include <stdint.h>
  
 /*=======================================================================\
 |                                                                       |
@@ -242,6 +243,14 @@ int i;
    }
    return(samples_read);
 }
+
+//! Byte swap short
+static int16_t swap_int16( int16_t val )
+{
+    return (val << 8) | ((val >> 8) & 0xFF);
+}
+
+
 
 /************************************************************************/
 /*
@@ -348,7 +357,7 @@ get_audio (
 
 	    for (i = 0; i < k; i++)
 		for (j = 0; j < 1152; j++)
-		    buffer[i][j] = insamp[k*j+i];
+		    buffer[i][j] = swap_int16(insamp[k*j+i]);
 	}
 	else 
 	{  /* layerII, stereo */

--- a/dist10/mc/encoder/encode.c
+++ b/dist10/mc/encoder/encode.c
@@ -213,6 +213,7 @@ int i;
    if (init) {
         samples_to_read = num_samples;
         init = FALSE;
+        fseek(musicin, 12+18, SEEK_SET);
    }
    if (samples_to_read >= frame_size)
         samples_read = frame_size;

--- a/dist10/mc/encoder/makefile
+++ b/dist10/mc/encoder/makefile
@@ -48,7 +48,7 @@
 # Compiler flags for UNIX
 CC		= cc
 #CFLAGS		= -DUNIX -g2 -DAugmentation_7ch -DPrintCRCDebug -DPrintBitDebug -DPRINTOUT -DDEBUG
-CFLAGS		= -DUNIX -g2 -DAugmentation_7ch
+CFLAGS		= -DUNIX -g2 -DAugmentation_7ch -Wno-implicit-function-declaration -Wno-implicit-int
 #CFLAGS		= -DUNIX -mips2 -O2
 LFLAGS		= -lm
 EXE_SUFFIX	=

--- a/dist10/mc/encoder/musicin.c
+++ b/dist10/mc/encoder/musicin.c
@@ -2731,7 +2731,7 @@ void aiff_check (char *file_name, IFF_AIFF *pcm_aiff_data)
     if (strcmp (pcm_aiff_data->sampleType, IFF_ID_SSND) != 0)
     {
        printf ("Sound data is not PCM in \"%s\".\n", file_name);
-       exit (1);
+       //exit (1);
     }
 
     if (SmpFrqIndex ((long) pcm_aiff_data->sampleRate) < 0)

--- a/dist10/mc/encoder/musicin.c
+++ b/dist10/mc/encoder/musicin.c
@@ -1718,7 +1718,7 @@ typedef unsigned int SUB[14][3][12][SBLIMIT]; /* JMZ 08/03/1995 */
 typedef double SAM[12];
 typedef unsigned int LSB[12];
 
-main (int argc, char **argv)
+int main (int argc, char **argv)
 {
     double  sb_sample[14][3][12][SBLIMIT];	/* JMZ 08/03/1995 */
     JSBS    *j_sample;

--- a/dist10/tool/pcm2aiff/pcm2aiff.c
+++ b/dist10/tool/pcm2aiff/pcm2aiff.c
@@ -59,7 +59,7 @@ char *	aiffFilenameSuffix	= ".aiff";
 
 /***************************************************************************/
 
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 char    file_name[50];
 int     i,j,c,disp,arg_count,config,aiff_mode;


### PR DESCRIPTION
It does not encode clearly on 64-bit aarch64 Termux tablet yet (a lot of noise), but Slackware 15.0 i586 seems to be working!

Not sure about dos stuff ...